### PR TITLE
fix go build for the latest libs and Go1.9 for ARM (raspberry pi)

### DIFF
--- a/promdump/promdump.go
+++ b/promdump/promdump.go
@@ -90,7 +90,8 @@ func main() {
 
 		query := fmt.Sprintf("%s[%ds]", *metric, int64(lookback))
 		log.Printf("Querying %s at %v", query, queryTS)
-		value, err := api.Query(ctx, query, queryTS)
+		value, err, _ := api.Query(ctx, query, queryTS)
+                
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/promremotewrite/promremotewrite.go
+++ b/promremotewrite/promremotewrite.go
@@ -36,14 +36,14 @@ var (
 // converts a slice of SampleStream messages into remote write requests and sends them into the channel.
 func generateWriteRequests(streams []*model.SampleStream, requests chan<- *prompb.WriteRequest) {
 	req := &prompb.WriteRequest{
-		Timeseries: make([]*prompb.TimeSeries, 0, 0),
+		Timeseries: make([]prompb.TimeSeries, 0, 0),
 	}
 
 	totalSamples := uint(0)
 	for _, s := range streams {
-		samples := make([]*prompb.Sample, 0, len(s.Values))
+		samples := make([]prompb.Sample, 0, len(s.Values))
 		for _, v := range s.Values {
-			samples = append(samples, &prompb.Sample{
+			samples = append(samples, prompb.Sample{
 				Value:     float64(v.Value),
 				Timestamp: int64(v.Timestamp),
 			})
@@ -53,12 +53,12 @@ func generateWriteRequests(streams []*model.SampleStream, requests chan<- *promp
 			Labels:  metricToLabelProtos(s.Metric),
 			Samples: samples,
 		}
-		req.Timeseries = append(req.Timeseries, &ts)
+		req.Timeseries = append(req.Timeseries, ts)
 		if totalSamples > *batchSize {
 			log.Printf("Sending batch of %d samples", totalSamples)
 			totalSamples = 0
 			requests <- req
-			req = &prompb.WriteRequest{Timeseries: make([]*prompb.TimeSeries, 0, 0)}
+			req = &prompb.WriteRequest{Timeseries: make([]prompb.TimeSeries, 0, 0)}
 		}
 	}
 
@@ -69,10 +69,10 @@ func generateWriteRequests(streams []*model.SampleStream, requests chan<- *promp
 // metricToLabelProtos builds a []*prompb.Label from a model.Metric
 // Copy/pasted from prometheus/storage/remote/codec.go (can't use it directly
 // because of vendoring in prometheus repo, see prometheus/issues/1720).
-func metricToLabelProtos(metric model.Metric) []*prompb.Label {
-	labels := make([]*prompb.Label, 0, len(metric))
+func metricToLabelProtos(metric model.Metric) []prompb.Label {
+	labels := make([]prompb.Label, 0, len(metric))
 	for k, v := range metric {
-		labels = append(labels, &prompb.Label{
+		labels = append(labels, prompb.Label{
 			Name:  string(k),
 			Value: string(v),
 		})


### PR DESCRIPTION
Hello
I am very new at Go, but I need to build this app.
I've tried to build under Raspberry Pi Go1.9 (https://storage.googleapis.com/golang/go1.9.linux-armv6l.tar.gz) and 
get errors for the **promdump**:

```
# _/home/pi/krepak-scripts/prometheus-remote-backfill/promdump
./promdump.go:93:14: cannot assign 3 values to 2 variables
```

I used `_` for the skip the third return value

and for the **promremotewrite**

```
# _/home/pi/krepak-scripts/prometheus-remote-backfill/promremotewrite
./promremotewrite.go:39:13: cannot use make([]*prompb.TimeSeries, 0, 0) (type []*prompb.TimeSeries) as type []prompb.TimeSeries in field value
./promremotewrite.go:53:10: cannot use metricToLabelProtos(s.Metric) (type []*prompb.Label) as type []prompb.Label in field value
./promremotewrite.go:54:11: cannot use samples (type []*prompb.Sample) as type []prompb.Sample in field value
./promremotewrite.go:56:26: cannot use &ts (type *prompb.TimeSeries) as type prompb.TimeSeries in append
./promremotewrite.go:61:41: cannot use make([]*prompb.TimeSeries, 0, 0) (type []*prompb.TimeSeries) as type []prompb.TimeSeries in field value
```

I've assume that is for the change pointers to maybe references in the dependency.

At the end it's successfully build **promremotewrite** and **promdump**

I've already use **promdump** and it writes json-file, but I only run `promremotewrite -h` without remote write to Prometheus server
